### PR TITLE
Fix the "distill_vec missing" error.

### DIFF
--- a/chroma_NAG.py
+++ b/chroma_NAG.py
@@ -44,7 +44,7 @@ def match_seq_len(tensor_to_resize, reference_tensor):
         return F.pad(tensor_to_resize, padding, "constant", 0)
 
 # This new forward function will contain the NAG logic for Chroma's DoubleStreamBlock.
-def chroma_doublestream_forward_nag(self, img, txt, pe, vec, attn_mask=None):
+def chroma_doublestream_forward_nag(self, img, txt, pe, vec=None, attn_mask=None, distill_vec=None):
     """
     A patched forward function for a DoubleStreamBlock that incorporates Normalized Attention Guidance.
     
@@ -60,6 +60,9 @@ def chroma_doublestream_forward_nag(self, img, txt, pe, vec, attn_mask=None):
         d. The rest of the block's operations (MLP, etc.) proceed with this guided result.
     """
     # Deconstruct modulation vectors
+    if distill_vec is not None:
+        vec = distill_vec
+        
     (img_mod1, img_mod2), (txt_mod1, txt_mod2) = vec
 
     


### PR DESCRIPTION
Hello again,

I had a weird error on my workflow where it says it was missing the "distill_vec" element, I added it on the code and it seems to be running fine that way.

By the way, I think your node is actually working, NAG isn't supposed to be used at CFG 1 on models that can't make it work naturally at CFG 1 (like Chroma).

On their paper, for undistilled models, they were forced to use CFG with NAG aswell.

![image](https://github.com/user-attachments/assets/389acac2-bf9b-4a6e-8421-a37e00d31fc2)

So this is what I got with Chroma + NAG with your node for example.

![combined_image](https://github.com/user-attachments/assets/34291b68-624d-4e25-b851-f5cdda6b033c)

